### PR TITLE
Add ServiceMgt AD group and members in bootstrapping

### DIFF
--- a/modules/asg/user_data/jitbit_instance.tpl
+++ b/modules/asg/user_data/jitbit_instance.tpl
@@ -87,10 +87,15 @@ Write-Output "Install & Config Log Rotation"
 Write-Output "------------------------------------"
 $User     = "${common_name}" + '\' + $ad_username.Value
 $Password = $ad_password.Value
-Add-LocalGroupMember -Group "Administrators" -Member $User , "Add JitBit Service account"  
+Add-LocalGroupMember -Group "Administrators" -Member $User
 New-Item C:\mgmt -ItemType Directory -ErrorAction Ignore
 Copy-S3Object -BucketName "${config_bucket}" -KeyPrefix mgmt -LocalFolder C:\mgmt
 Register-ScheduledTask -TaskName "jitbit_log_rotation" -Xml (Get-Content "C:\mgmt\iis_log_rotation.xml" | Out-String)  -Force -User $User -Password $Password
+
+Write-Output "------------------------------------"
+Write-Output "Adding Service Management Team"
+Write-Output "------------------------------------"
+Add-LocalGroupMember -Group "Administrators" -Member "$common_name\ServiceMgmt"
 
 </powershell>
 <persist>true</persist>

--- a/scripts/CreateADGroups.ps1
+++ b/scripts/CreateADGroups.ps1
@@ -1,0 +1,50 @@
+Clear-Host
+
+# In-line function to create an AD group
+function CreateADGroup {
+    
+  param (
+    [string]$ADGroupName
+  )
+
+  try {
+       $group = Get-ADGroup -Identity $ADGroupName
+       write-output "--- Group $ADGroupName already exists ---"
+  }
+  catch {
+      write-output "---------------------------------------------------------------------------------"
+      write-output "--- Creating AD Group $ADGroupName ---"
+
+      $Description = "$ADGroupName users"
+      New-ADGroup -Name $ADGroupName -SAMAccountName $ADGroupName -GroupCategory "Security" -GroupScope "Global" -DisplayName $ADGroupName -Description $Description
+      write-output ""
+  }
+}
+
+# Get the instance id from ec2 meta data
+$instanceid = Invoke-RestMethod "http://169.254.169.254/latest/meta-data/instance-id"
+
+# Get the environment name and application from this instance's environment-name and application tag values
+$environmentName = Get-EC2Tag -Filter @(
+        @{
+            name="resource-id"
+            values="$instanceid"
+        }
+        @{
+            name="key"
+            values="environment-name"
+        }
+    )
+$domainname = $environmentName.Value
+
+
+## Create the groups
+$groups = @("ServiceMgmt")
+
+write-output '================================================================================'
+write-output " Creating groups in ${domainname}.local"
+write-output '================================================================================'
+foreach ($group in $groups) {
+  Write-Output "Creating group ${group}"
+  CreateADGroup $group
+}

--- a/scripts/CreateADUsers.ps1
+++ b/scripts/CreateADUsers.ps1
@@ -111,8 +111,6 @@ $AdminTeamGroups = @("CN=AWS Delegated Administrators,OU=AWS Delegated Groups,DC
 write-output '================================================================================'
 write-output " Creating AD Admin Users and Adding to AD Domain Groups in ${domainname}.local"
 write-output '================================================================================'
- 
-
 foreach ($user in $AdminUsers) {
    
    $OUUserPath="CN=${user}${OUUsersPathSuffix}"
@@ -124,6 +122,26 @@ foreach ($user in $AdminUsers) {
      
    foreach ($group in $AdminTeamGroups) {
       Write-Output "Adding User '$user' to group '$AdminTeamGroups'"
+      AddGroupMember $user $group
+   }
+   Write-Output "Enabling user account ${user}"
+   Enable-ADAccount -Identity $user
+}
+
+# Service Management Users
+$ServiceMgmtUsers = @('StevenHorner')
+$ServiceMgmtGroups = @('ServiceMgmt')
+
+write-output '================================================================================'
+write-output " Creating Service Mgmt users and add to AD Domain Groups in ${domainname}.local"
+write-output '================================================================================'
+foreach ($user in $ServiceMgmtUsers) {
+   $SecureAccountPassword = New-RandomPassword -MinimumPasswordLength 10 -MaximumPasswordLength 15 -NumberOfAlphaNumericCharacters 6 -ConvertToSecureString
+
+   CreateADUser $user $SecureAccountPassword "Service Management Team"
+     
+   foreach ($group in $ServiceMgmtGroups) {
+      Write-Output "Adding User '$user' to group '$group'"
       AddGroupMember $user $group
    }
    Write-Output "Enabling user account ${user}"


### PR DESCRIPTION
Relates to https://dsdmoj.atlassian.net/browse/NIT-14

In order for the jitbit service management team to be able to perform updates to jitbit environments, they need access to the AD-joined windows servers. This change adds 
- code in the one-off AD scripts to create a new AD group called ServiceMgmt
- code in the one-off AD scripts to add a member to the group
- code in the bootstrapping to add the domain group to the windows server Administrators local group.

The one-off AD scripts have been run already, but I'd like to get the bootstrapping updated and tested.