### PR TITLE
Making the active_directory-log-policy name dynamic on env

### DIFF
--- a/modules/activedirectory/activedirectory.tf
+++ b/modules/activedirectory/activedirectory.tf
@@ -1,15 +1,15 @@
 resource "aws_directory_service_directory" "active_directory" {
-  name        = var.ad.name
-  short_name  = var.ad.short_name 
+  name       = var.ad.name
+  short_name = var.ad.short_name
 
   description = "Microsoft AD for ${var.common.environment_name}.local"
-  
-#   TO Do
-  password    = var.ad.admin_password
 
-  enable_sso  = false
-  type        = "MicrosoftAD"
-  edition     = "Standard"
+  #   TO Do
+  password = var.ad.admin_password
+
+  enable_sso = false
+  type       = "MicrosoftAD"
+  edition    = "Standard"
 
 
   vpc_settings {

--- a/modules/activedirectory/cloudwatch-logs.tf
+++ b/modules/activedirectory/cloudwatch-logs.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "ad-log-policy" {
 
 resource "aws_cloudwatch_log_resource_policy" "active_directory-log-policy" {
   policy_document = data.aws_iam_policy_document.ad-log-policy.json
-  policy_name     = "ad-log-policy"
+  policy_name     = "ad-log-policy-${var.common.environment_name}"
 }
 
 resource "aws_directory_service_log_subscription" "active_directory" {

--- a/modules/activedirectory/locals.tf
+++ b/modules/activedirectory/locals.tf
@@ -1,6 +1,6 @@
-locals{
-    directory_id         = aws_directory_service_directory.active_directory.id
-    directory_name       = aws_directory_service_directory.active_directory.name
-    directory_short_name = aws_directory_service_directory.active_directory.short_name
-    directory_dns_ips    = sort(aws_directory_service_directory.active_directory.dns_ip_addresses)
+locals {
+  directory_id         = aws_directory_service_directory.active_directory.id
+  directory_name       = aws_directory_service_directory.active_directory.name
+  directory_short_name = aws_directory_service_directory.active_directory.short_name
+  directory_dns_ips    = sort(aws_directory_service_directory.active_directory.dns_ip_addresses)
 }


### PR DESCRIPTION
As discussed on a call this morning, making this policy name dynamic should means going forward we will have a different policy for each of the 3 dev environments (dev, preprod, training)
This is re - https://dsdmoj.atlassian.net/browse/NIT-25